### PR TITLE
[TRN-502] remove some sql-injection rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -668,7 +668,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
 
 ## OWASP Top 10 A1
 ### Mitigate SQL Injection Attacks
-### Matches attempted SQLi patterns in the URI, QUERY_STRING, BODY, COOKIES
+### Matches attempted SQLi patterns in the URI, QUERY_STRING, COOKIES
 resource "aws_waf_sql_injection_match_set" "owasp_01_sql_injection_set" {
   count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
 
@@ -703,22 +703,6 @@ resource "aws_waf_sql_injection_match_set" "owasp_01_sql_injection_set" {
 
     field_to_match {
       type = "QUERY_STRING"
-    }
-  }
-
-  sql_injection_match_tuples {
-    text_transformation = "URL_DECODE"
-
-    field_to_match {
-      type = "BODY"
-    }
-  }
-
-  sql_injection_match_tuples {
-    text_transformation = "HTML_ENTITY_DECODE"
-
-    field_to_match {
-      type = "BODY"
     }
   }
 


### PR DESCRIPTION
### Description

Gengo has no control over the source that the customers are sending. Sources may contain URLs that are not allowed because of these filters. We don't use these source and target as a condition in any queries anyway. 

### Ticket
- https://gengo.atlassian.net/browse/TRN-502

### Risk
 - We really need it. Another solution is to separate workbench router from other routes.